### PR TITLE
SnmpV3Users Idempotency fix for privacyPassphrase

### DIFF
--- a/plugins/module_utils/oneview.py
+++ b/plugins/module_utils/oneview.py
@@ -311,8 +311,8 @@ def compare(first_resource, second_resource, parameter_to_ignore=None):
             logger.debug("%s %s", OneViewModuleBase.MSG_DIFF_AT_KEY.format(
                 key), debug_resources)
             if parameter_to_ignore is not None:
-               parameter_to_ignore_lower = [i.lower() for i in parameter_to_ignore]
-               if key.lower() in parameter_to_ignore_lower:
+                parameter_to_ignore_lower = [i.lower() for i in parameter_to_ignore]
+                if key.lower() in parameter_to_ignore_lower:
                     continue
             return False
 

--- a/plugins/module_utils/oneview.py
+++ b/plugins/module_utils/oneview.py
@@ -311,7 +311,8 @@ def compare(first_resource, second_resource, parameter_to_ignore=None):
             logger.debug("%s %s", OneViewModuleBase.MSG_DIFF_AT_KEY.format(
                 key), debug_resources)
             if parameter_to_ignore is not None:
-                if key.lower() == parameter_to_ignore.lower():
+               parameter_to_ignore_lower = [i.lower() for i in parameter_to_ignore]
+               if key.lower() in parameter_to_ignore_lower:
                     continue
             return False
 

--- a/plugins/modules/oneview_appliance_device_snmp_v3_users.py
+++ b/plugins/modules/oneview_appliance_device_snmp_v3_users.py
@@ -138,7 +138,7 @@ class ApplianceDeviceSnmpV3UsersModule(OneViewModule):
         self.set_resource_object(self.oneview_client.appliance_device_snmp_v3_users)
 
     def execute_module(self):
-        parameter_to_ignore = "authenticationPassphrase"
+        parameter_to_ignore = ["authenticationPassphrase", "privacyPassphrase"]
         if self.oneview_client.api_version < 600:
             raise OneViewModuleValueError(self.MSG_API_VERSION_ERROR)
         if self.state == 'present':


### PR DESCRIPTION
### Description
Adds privacyPassphrase to parameter_to_ignore list to avoid idempotency issue

### Issues Resolved
#179 

### Check List
- [ ] New functionality includes sanity testing.
  - [ ] All sanity tests pass. (`$ ansible-test sanity`).
  - [ ] All unit tests pass.
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
