### PR TITLE
Certificates Server Idempotency Issue #178

### DIFF
--- a/plugins/module_utils/oneview.py
+++ b/plugins/module_utils/oneview.py
@@ -105,7 +105,7 @@ def dict_merge(original_resource_dict, data_dict):
         elif isinstance(resource_dict[key], dict) and isinstance(data_dict[key], Mapping):
             resource_dict[key] = dict_merge(resource_dict[key], data_dict[key])
         elif isinstance(resource_dict[key], list) and isinstance(data_dict[key], list):
-            if len(resource_dict[key])==1 and len(data_dict[key])==1:
+            if len(resource_dict[key]) == 1 and len(data_dict[key]) == 1:
                 if isinstance(resource_dict[key][0], dict) and isinstance(data_dict[key][0], dict):
                     resource_dict[key][0] = dict_merge(resource_dict[key][0], data_dict[key][0])
                 else:

--- a/plugins/module_utils/oneview.py
+++ b/plugins/module_utils/oneview.py
@@ -105,8 +105,9 @@ def dict_merge(original_resource_dict, data_dict):
         elif isinstance(resource_dict[key], dict) and isinstance(data_dict[key], Mapping):
             resource_dict[key] = dict_merge(resource_dict[key], data_dict[key])
         elif isinstance(resource_dict[key], list) and isinstance(data_dict[key], list):
+            #To handle merging when there is only one element in list and there by avoiding idempotency
             if len(resource_dict[key]) == 1 and len(data_dict[key]) == 1:
-                if isinstance(resource_dict[key][0], dict) and isinstance(data_dict[key][0], dict):
+                if isinstance(resource_dict[key][0], dict) and isinstance(data_dict[key][0], Mapping):
                     resource_dict[key][0] = dict_merge(resource_dict[key][0], data_dict[key][0])
                 else:
                     resource_dict[key] = data_dict[key]
@@ -317,7 +318,8 @@ def compare(first_resource, second_resource, parameter_to_ignore=None):
             logger.debug("%s %s", OneViewModuleBase.MSG_DIFF_AT_KEY.format(
                 key), debug_resources)
             if parameter_to_ignore is not None:
-                if key.lower() == parameter_to_ignore.lower():
+                parameter_to_ignore_lower = [i.lower() for i in parameter_to_ignore]
+                if key.lower() in parameter_to_ignore_lower:
                     continue
             return False
 
@@ -758,11 +760,13 @@ class OneViewModule(object):
         updated_data = self.current_resource.data.copy()
         updated_data = dict_merge(updated_data, self.data)
         changed = False
-
+        open('/home/alisha/loguplink.txt', 'w').write("CurrentResourceData:"+str(self.current_resource.data))
+        open('/home/alisha/loguplink.txt', 'a').write("\nUpdated Data:"+str(updated_data))
         if compare(self.current_resource.data, updated_data, parameter_to_ignore):
             msg = self.MSG_ALREADY_PRESENT
         else:
             self.current_resource.update(updated_data)
+            open('/home/alisha/loguplink.txt', 'a').write("\nCurrentResourceData:"+str(self.current_resource.data))
             changed = True
             msg = self.MSG_UPDATED
 

--- a/plugins/module_utils/oneview.py
+++ b/plugins/module_utils/oneview.py
@@ -105,7 +105,13 @@ def dict_merge(original_resource_dict, data_dict):
         elif isinstance(resource_dict[key], dict) and isinstance(data_dict[key], Mapping):
             resource_dict[key] = dict_merge(resource_dict[key], data_dict[key])
         elif isinstance(resource_dict[key], list) and isinstance(data_dict[key], list):
-            resource_dict[key] = data_dict[key]
+            if len(resource_dict[key])==1 and len(data_dict[key])==1:
+                if isinstance(resource_dict[key][0], dict) and isinstance(data_dict[key][0], dict):
+                    resource_dict[key][0] = dict_merge(resource_dict[key][0], data_dict[key][0])
+                else:
+                    resource_dict[key] = data_dict[key]
+            else:
+                resource_dict[key] = data_dict[key]
         else:
             resource_dict[key] = val
 

--- a/plugins/module_utils/oneview.py
+++ b/plugins/module_utils/oneview.py
@@ -105,7 +105,7 @@ def dict_merge(original_resource_dict, data_dict):
         elif isinstance(resource_dict[key], dict) and isinstance(data_dict[key], Mapping):
             resource_dict[key] = dict_merge(resource_dict[key], data_dict[key])
         elif isinstance(resource_dict[key], list) and isinstance(data_dict[key], list):
-            #To handle merging when there is only one element in list and there by avoiding idempotency
+            # To handle merging when there is only one element in list and there by avoiding idempotency
             if len(resource_dict[key]) == 1 and len(data_dict[key]) == 1:
                 if isinstance(resource_dict[key][0], dict) and isinstance(data_dict[key][0], Mapping):
                     resource_dict[key][0] = dict_merge(resource_dict[key][0], data_dict[key][0])
@@ -760,13 +760,10 @@ class OneViewModule(object):
         updated_data = self.current_resource.data.copy()
         updated_data = dict_merge(updated_data, self.data)
         changed = False
-        open('/home/alisha/loguplink.txt', 'w').write("CurrentResourceData:"+str(self.current_resource.data))
-        open('/home/alisha/loguplink.txt', 'a').write("\nUpdated Data:"+str(updated_data))
         if compare(self.current_resource.data, updated_data, parameter_to_ignore):
             msg = self.MSG_ALREADY_PRESENT
         else:
             self.current_resource.update(updated_data)
-            open('/home/alisha/loguplink.txt', 'a').write("\nCurrentResourceData:"+str(self.current_resource.data))
             changed = True
             msg = self.MSG_UPDATED
 

--- a/tests/unit/test_oneview.py
+++ b/tests/unit/test_oneview.py
@@ -2045,15 +2045,15 @@ class TestOneViewModuleBase():
         assert merged_dict == expected_dict
 
     def test_merge_dict_with_multiple_element_list_inside_dict(self):
-        original_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000),
+        original_dict = dict(test11=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000),
                                      dict(id=1, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
 
-        dict_with_changes = dict(test1=[dict(id=2, requestedMbps=2700, allocatedVFs=3500),
+        dict_with_changes = dict(test11=[dict(id=2, requestedMbps=2700, allocatedVFs=3500),
                                          dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
 
         merged_dict = dict_merge(original_dict, dict_with_changes)
 
-        expected_dict = dict(test1=[dict(id=2, requestedMbps=2700, allocatedVFs=3500),
+        expected_dict = dict(test11=[dict(id=2, requestedMbps=2700, allocatedVFs=3500),
                                      dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
 
         assert merged_dict == expected_dict

--- a/tests/unit/test_oneview.py
+++ b/tests/unit/test_oneview.py
@@ -45,6 +45,7 @@ from ansible_collections.hpe.oneview.plugins.module_utils.oneview import (OneVie
                                                                           _sort_by_keys,
                                                                           _str_sorted,
                                                                           merge_list_by_key,
+                                                                          dict_merge,
                                                                           transform_list_to_dict,
                                                                           compare,
                                                                           compare_lig,
@@ -2032,6 +2033,17 @@ class TestOneViewModuleBase():
                          dict(networkType="Ethernet", name="name-2")]
         assert result1 == expected_list
 
+
+    def test_merge_dict_with_single_element_list_inside_dict(self):
+        original_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
+
+        dict_with_changes = dict(test1=[dict(id=2, requestedMbps=2700, allocatedVFs=3500)])
+
+        merged_dict = dict_merge(original_dict, dict_with_changes)
+
+        expected_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=2700, allocatedVFs=3500)])
+
+        assert merged_dict == expected_dict
 
 class TestServerProfileReplaceNamesByUris():
     SERVER_PROFILE_NAME = "Profile101"

--- a/tests/unit/test_oneview.py
+++ b/tests/unit/test_oneview.py
@@ -2045,16 +2045,16 @@ class TestOneViewModuleBase():
         assert merged_dict == expected_dict
 
     def test_merge_dict_with_multiple_element_list_inside_dict(self):
-        original_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000), 
-                                    dict(id=1, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
+        original_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000),
+                                     dict(id=1, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
 
-        dict_with_changes = dict(test1=[dict(id=2, requestedMbps=2700, allocatedVFs=3500), 
-                            dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
+        dict_with_changes = dict(test1=[dict(id=2, requestedMbps=2700, allocatedVFs=3500),
+                                         dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
 
         merged_dict = dict_merge(original_dict, dict_with_changes)
 
-        expected_dict = dict(test1=[dict(id=2, requestedMbps=2700, allocatedVFs=3500), 
-                        dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
+        expected_dict = dict(test1=[dict(id=2, requestedMbps=2700, allocatedVFs=3500),
+                                     dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
 
         assert merged_dict == expected_dict
 

--- a/tests/unit/test_oneview.py
+++ b/tests/unit/test_oneview.py
@@ -2044,6 +2044,38 @@ class TestOneViewModuleBase():
 
         assert merged_dict == expected_dict
 
+    def test_merge_dict_with_multiple_element_list_inside_dict(self):
+        original_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000),dict(id=1, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
+
+        dict_with_changes = dict(test1=[dict(id=2, requestedMbps=2700, allocatedVFs=3500), dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
+
+        merged_dict = dict_merge(original_dict, dict_with_changes)
+
+        expected_dict = dict(test1=[dict(id=2, requestedMbps=2700, allocatedVFs=3500), dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
+
+        assert merged_dict == expected_dict
+
+    def test_merge_dict_with_same_data_list_inside_dict(self):
+        original_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
+
+        dict_with_changes = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
+
+        merged_dict = dict_merge(original_dict, dict_with_changes)
+
+        expected_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
+
+        assert merged_dict == expected_dict
+
+    def test_merge_dict_with_empty_data_list_inside_dict(self):
+        original_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
+
+        dict_with_changes = dict(test1=[dict()])
+
+        merged_dict = dict_merge(original_dict, dict_with_changes)
+
+        expected_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
+
+        assert merged_dict == expected_dict
 
 class TestServerProfileReplaceNamesByUris():
     SERVER_PROFILE_NAME = "Profile101"

--- a/tests/unit/test_oneview.py
+++ b/tests/unit/test_oneview.py
@@ -2046,15 +2046,15 @@ class TestOneViewModuleBase():
 
     def test_merge_dict_with_multiple_element_list_inside_dict(self):
         original_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000),
-                                     dict(id=1, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
+                         dict(id=1, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
 
         dict_with_changes = dict(test1=[dict(id=2, requestedMbps=2700, allocatedVFs=3500),
-                                         dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
+                             dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
 
         merged_dict = dict_merge(original_dict, dict_with_changes)
 
         expected_dict = dict(test1=[dict(id=2, requestedMbps=2700, allocatedVFs=3500),
-                                     dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
+                         dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
 
         assert merged_dict == expected_dict
 

--- a/tests/unit/test_oneview.py
+++ b/tests/unit/test_oneview.py
@@ -2045,13 +2045,16 @@ class TestOneViewModuleBase():
         assert merged_dict == expected_dict
 
     def test_merge_dict_with_multiple_element_list_inside_dict(self):
-        original_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000),dict(id=1, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
+        original_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000), 
+                                    dict(id=1, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
 
-        dict_with_changes = dict(test1=[dict(id=2, requestedMbps=2700, allocatedVFs=3500), dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
+        dict_with_changes = dict(test1=[dict(id=2, requestedMbps=2700, allocatedVFs=3500), 
+                            dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
 
         merged_dict = dict_merge(original_dict, dict_with_changes)
 
-        expected_dict = dict(test1=[dict(id=2, requestedMbps=2700, allocatedVFs=3500), dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
+        expected_dict = dict(test1=[dict(id=2, requestedMbps=2700, allocatedVFs=3500), 
+                        dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
 
         assert merged_dict == expected_dict
 
@@ -2076,6 +2079,7 @@ class TestOneViewModuleBase():
         expected_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
 
         assert merged_dict == expected_dict
+
 
 class TestServerProfileReplaceNamesByUris():
     SERVER_PROFILE_NAME = "Profile101"

--- a/tests/unit/test_oneview.py
+++ b/tests/unit/test_oneview.py
@@ -2046,15 +2046,15 @@ class TestOneViewModuleBase():
 
     def test_merge_dict_with_multiple_element_list_inside_dict(self):
         original_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000),
-                         dict(id=1, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
+                                     dict(id=1, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
 
         dict_with_changes = dict(test1=[dict(id=2, requestedMbps=2700, allocatedVFs=3500),
-                             dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
+                                         dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
 
         merged_dict = dict_merge(original_dict, dict_with_changes)
 
         expected_dict = dict(test1=[dict(id=2, requestedMbps=2700, allocatedVFs=3500),
-                         dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
+                                     dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
 
         assert merged_dict == expected_dict
 

--- a/tests/unit/test_oneview.py
+++ b/tests/unit/test_oneview.py
@@ -2033,7 +2033,6 @@ class TestOneViewModuleBase():
                          dict(networkType="Ethernet", name="name-2")]
         assert result1 == expected_list
 
-
     def test_merge_dict_with_single_element_list_inside_dict(self):
         original_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
 
@@ -2044,6 +2043,7 @@ class TestOneViewModuleBase():
         expected_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=2700, allocatedVFs=3500)])
 
         assert merged_dict == expected_dict
+
 
 class TestServerProfileReplaceNamesByUris():
     SERVER_PROFILE_NAME = "Profile101"


### PR DESCRIPTION
### Description
Modifying dict_merge in oneview.py to avoid idempotency

### Issues Resolved
#178 

### Check List
- [ ] New functionality includes sanity testing.
  - [ ] All sanity tests pass. (`$ ansible-test sanity`).
  - [ ] All unit tests pass.
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
