### PR TITLE
Issue _178:Certificates Idempotency

### DIFF
--- a/plugins/module_utils/oneview.py
+++ b/plugins/module_utils/oneview.py
@@ -105,7 +105,14 @@ def dict_merge(original_resource_dict, data_dict):
         elif isinstance(resource_dict[key], dict) and isinstance(data_dict[key], Mapping):
             resource_dict[key] = dict_merge(resource_dict[key], data_dict[key])
         elif isinstance(resource_dict[key], list) and isinstance(data_dict[key], list):
-            resource_dict[key] = data_dict[key]
+            # To handle merging when there is only one element in list and there by avoiding idempotency
+            if len(resource_dict[key]) == 1 and len(data_dict[key]) == 1:
+                if isinstance(resource_dict[key][0], dict) and isinstance(data_dict[key][0], Mapping):
+                    resource_dict[key][0] = dict_merge(resource_dict[key][0], data_dict[key][0])
+                else:
+                    resource_dict[key] = data_dict[key]
+            else:
+                resource_dict[key] = data_dict[key]
         else:
             resource_dict[key] = val
 

--- a/tests/unit/test_oneview.py
+++ b/tests/unit/test_oneview.py
@@ -2033,7 +2033,6 @@ class TestOneViewModuleBase():
                          dict(networkType="Ethernet", name="name-2")]
         assert result1 == expected_list
 
-
     def test_merge_dict_with_single_element_list_inside_dict(self):
         original_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
 

--- a/tests/unit/test_oneview.py
+++ b/tests/unit/test_oneview.py
@@ -45,6 +45,7 @@ from ansible_collections.hpe.oneview.plugins.module_utils.oneview import (OneVie
                                                                           _sort_by_keys,
                                                                           _str_sorted,
                                                                           merge_list_by_key,
+                                                                          dict_merge,
                                                                           transform_list_to_dict,
                                                                           compare,
                                                                           compare_lig,
@@ -2031,6 +2032,54 @@ class TestOneViewModuleBase():
         expected_list = [dict(networkType="Ethernet", name="name-1"),
                          dict(networkType="Ethernet", name="name-2")]
         assert result1 == expected_list
+
+
+    def test_merge_dict_with_single_element_list_inside_dict(self):
+        original_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
+
+        dict_with_changes = dict(test1=[dict(id=2, requestedMbps=2700, allocatedVFs=3500)])
+
+        merged_dict = dict_merge(original_dict, dict_with_changes)
+
+        expected_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=2700, allocatedVFs=3500)])
+
+        assert merged_dict == expected_dict
+
+    def test_merge_dict_with_multiple_element_list_inside_dict(self):
+        original_dict = dict(test11=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000),
+                                     dict(id=1, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
+
+        dict_with_changes = dict(test11=[dict(id=2, requestedMbps=2700, allocatedVFs=3500),
+                                         dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
+
+        merged_dict = dict_merge(original_dict, dict_with_changes)
+
+        expected_dict = dict(test11=[dict(id=2, requestedMbps=2700, allocatedVFs=3500),
+                                     dict(id=3, allocatedMbps=600, mac="E8:4B:0Y:30:08:0B", requestedMbps=900)])
+
+        assert merged_dict == expected_dict
+
+    def test_merge_dict_with_same_data_list_inside_dict(self):
+        original_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
+
+        dict_with_changes = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
+
+        merged_dict = dict_merge(original_dict, dict_with_changes)
+
+        expected_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
+
+        assert merged_dict == expected_dict
+
+    def test_merge_dict_with_empty_data_list_inside_dict(self):
+        original_dict = dict(test1=[dict(id=2, allocatedMbps=1000, mac="E2:4B:0D:30:00:0B", requestedMbps=1000)])
+
+        dict_with_changes = dict(test1=[])
+
+        merged_dict = dict_merge(original_dict, dict_with_changes)
+
+        expected_dict = dict(test1=[])
+
+        assert merged_dict == expected_dict
 
 
 class TestServerProfileReplaceNamesByUris():


### PR DESCRIPTION
### Description
Modifying dict_merge in oneview.py to avoid idempotency

### Issues Resolved
#178 

### Check List
- [ ] New functionality includes sanity testing.
  - [ ] All sanity tests pass. (`$ ansible-test sanity`).
  - [ ] All unit tests pass.
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
